### PR TITLE
Update trade history calls

### DIFF
--- a/main.py
+++ b/main.py
@@ -42,9 +42,10 @@ async def pipeline(config: dict):
         confidence_file = await confidence_scoring(symbol_save_file, tf, indicator_file, pattern_file, paths["confidence"], timestamp)
         logic_file = await select_logic_trade(symbol_save_file, tf, regime_file, paths["logic_trade"], timestamp)
         lot_file = await calculate_lot_size(symbol_save_file, tf, confidence_file, risk, balance, paths["lot_size"], timestamp)
-        order_file = await create_order(symbol_market, tf, logic_file, lot_file, paths["orders"], timestamp)
-        await fetch_trade_history(symbol_market, paths["trade_history"])
-        await update_win_rate(symbol_market, paths["win_rate"])
+        await create_order(symbol_market, tf, logic_file, lot_file, paths["orders"], timestamp)
+
+    await fetch_trade_history(symbol_market, paths["trade_history"])
+    await update_win_rate(symbol_market, paths["win_rate"])
 
 
 async def main():


### PR DESCRIPTION
## Summary
- call `fetch_trade_history` and `update_win_rate` once after processing all timeframes

## Testing
- `python -m py_compile main.py modules/*/*.py modules/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6885e82418d88320816d0dbba44fb949