### PR TITLE
Refactor win-rate notifications

### DIFF
--- a/main.py
+++ b/main.py
@@ -38,6 +38,9 @@ async def pipeline(config: dict):
     tz_shift = fetch_cfg.get("tz_shift", 0)
     timestamp = int(time.time())
 
+    telegram_order_cfg = main_cfg.get("notify", {}).get("telegram_order", {})
+    telegram_win_cfg = main_cfg.get("notify", {}).get("telegram_win_rate", {})
+
     for tf in timeframes:
         logging.info("processing timeframe %s", tf)
 
@@ -153,7 +156,7 @@ async def pipeline(config: dict):
                 lot_file,
                 paths["orders"],
                 timestamp,
-                main_cfg.get("notify", {}).get("telegram_order", {}),
+                telegram_order_cfg,
                 main_cfg.get("account_name", ""),
             )
             logging.info("Creating order complete")
@@ -169,7 +172,7 @@ async def pipeline(config: dict):
 
     try:
         logging.info("Updating win rate...")
-        await update_win_rate(symbol_save_file, paths["win_rate"])
+        await update_win_rate(symbol_save_file, paths["win_rate"], telegram_win_cfg)
         logging.info("Updating win rate complete")
     except Exception:
         logging.exception("Updating win rate failed")

--- a/modules/reportTrade/winRate.py
+++ b/modules/reportTrade/winRate.py
@@ -1,9 +1,21 @@
 import logging
 from pathlib import Path
 
+from modules.create_pending_order_sendMt5 import send_telegram
 
-async def update_win_rate(symbol: str, directory: Path) -> Path:
-    """Update win rate statistics and store to ``<symbol>_win_rate.csv``."""
+
+async def update_win_rate(symbol: str, directory: Path, telegram_cfg: dict | None = None) -> Path:
+    """Update win rate statistics and store to ``<symbol>_win_rate.csv``.
+
+    Parameters
+    ----------
+    symbol : str
+        Trading symbol used for the report.
+    directory : Path
+        Directory where the win rate csv will be stored.
+    telegram_cfg : dict, optional
+        Telegram configuration for sending notifications.
+    """
     logging.info("start update_win_rate %s", symbol)
     try:
         directory.mkdir(parents=True, exist_ok=True)
@@ -14,7 +26,11 @@ async def update_win_rate(symbol: str, directory: Path) -> Path:
             path.write_text("win_rate\n")
         # placeholder for win rate calculation
         logging.info("completed update_win_rate %s", symbol)
+        if telegram_cfg is not None:
+            await send_telegram(telegram_cfg, f"update win rate completed for {symbol}")
         return path
     except Exception:
         logging.exception("error in update_win_rate %s", symbol)
+        if telegram_cfg is not None:
+            await send_telegram(telegram_cfg, f"update win rate failed for {symbol}")
         raise


### PR DESCRIPTION
## Summary
- adjust pipeline to pull telegram configs once and pass into helpers
- send win-rate notifications using config notify section

## Testing
- `python3 -m py_compile main.py modules/*/*.py modules/*.py`
- `python3 main.py` *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_6885ee9cc88c8320933a35ae37d546f6