### PR TITLE
Fix telegram config key typo

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,8 +3,8 @@
         "interval": 300,
         "account_name": "DEMO_account",
         "notify": {
-            "telegram_order": { "enbled": true, "token": "", "chatid": "" },
-            "telegram_win_rate": { "enbled": true, "token": "", "chatid": "" }
+            "telegram_order": { "enabled": true, "token": "", "chatid": "" },
+            "telegram_win_rate": { "enabled": true, "token": "", "chatid": "" }
         }
     },
     "fetch": {

--- a/modules/create_pending_order_sendMt5.py
+++ b/modules/create_pending_order_sendMt5.py
@@ -18,7 +18,7 @@ async def send_mt5(order: dict) -> bool:
 
 async def send_telegram(cfg: dict, text: str) -> bool:
     """Send a telegram message using the provided configuration."""
-    if not cfg.get("enbled"):
+    if not cfg.get("enabled"):
         return False
     token = cfg.get("token")
     chat_id = cfg.get("chatid")


### PR DESCRIPTION
## Summary
- update notification settings to use `enabled`
- adjust telegram helper to respect new setting name

## Testing
- `PYTHONDONTWRITEBYTECODE=1 python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6885f2ca6ba483208642ae7a70fa2129